### PR TITLE
Add common settings and tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,29 @@
 ARG JULIA_VERSION=1
 FROM julia:${JULIA_VERSION}
+
+# Options for common setup script
+# Install zsh & Oh-My-Zsh
+ARG INSTALL_ZSH="true"
+# Upgrade OS packages to their latest versions
+ARG UPGRADE_PACKAGES="true"
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SHA="dev-mode"
+
+# This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in
+# devcontainer.json to use it. More info: https://aka.ms/vscode-remote/containers/non-root-user.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Install needed packages and setup non-root user.
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends curl ca-certificates 2>&1 \
+    && curl -sSL  ${COMMON_SCRIPT_SOURCE} -o /tmp/common-setup.sh \
+    && ([ "${COMMON_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/common-setup.sh" | sha256sum -c -)) \
+    && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && rm /tmp/common-setup.sh \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# container-images
+# Julia dev container definition
+Julia dev container definitions for VS Code Remote Development / Codespaces Container.
+
+---
+
+This repository contains the dev container definition for the Julia Programming language. The development container [Docker](https://www.docker.com) images contain a miminal tool/runtime stack and its prerequisites to help you get up and running with Julia development in a containerized environment.
+
+# Getting started
+
+Just follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the Julia definition.
+
+3. After following step 2, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+4. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # Julia dev container definition
-Julia dev container definitions for VS Code Remote Development / Codespaces Container.
-
----
 
 This repository contains the dev container definition for the Julia Programming language. The development container [Docker](https://www.docker.com) images contain a miminal tool/runtime stack and its prerequisites to help you get up and running with Julia development in a containerized environment.
 


### PR DESCRIPTION
As discussed in https://github.com/microsoft/vscode-dev-containers/pull/450 I updated the container definition. Before removing the draft status I would like to double check the following: 

Currently, the container definition refers to the common-debian script from https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh. I wasn't sure what would be the best approach. Either add a copy to our repo or to have it point to the microsoft/vscode-dev-containers as an external dependency. What would you prefer?