### PR TITLE
Build for multiple architectures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --build-arg JULIA_VERSION=${{ matrix.julia-version }}
+        run: |
+          docker buildx create --use --bootstrap
+          docker buildx build . --file Dockerfile --tag $IMAGE_NAME --build-arg JULIA_VERSION=${{ matrix.julia-version }} --platform linux/amd64,linux/arm64
 
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
@@ -91,7 +93,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --build-arg JULIA_VERSION=latest
+        run: |
+          docker buildx --use --bootstrap
+          docker buildx build . --file Dockerfile --tag $IMAGE_NAME --build-arg JULIA_VERSION=latest --platform linux/amd64,linux/arm64
 
       - name: Log into GitHub Container Registry
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin


### PR DESCRIPTION
I'm having problems running the `julia-devcontainer` in Apple M-series.
```
vscode@80cf02809eed /w/Extrae.jl (master)> julia
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
fish: Job 1, 'julia' terminated by signal SIGSEGV (Address boundary error)
```

The problem is that `julia-devcontainer` image is only built for x86_64.
```
vscode@80cf02809eed /w/Extrae.jl (master)> file $(which julia)
/usr/local/julia/bin/julia: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.4.0, with debug_info, not stripped
```

This PR add support for multi-platform image building (currently x86_64 and aarch64).
